### PR TITLE
add dump_template options for S3 upload

### DIFF
--- a/lib/kumogata2/cli/option_parser.rb
+++ b/lib/kumogata2/cli/option_parser.rb
@@ -72,6 +72,10 @@ module Kumogata2::CLI
         description: 'Show template information for a specified stack',
         arguments: [:path_or_url],
       },
+      dump_template: {
+        description: 'Dumps template file for a specified stack(useful for update stack via S3)',
+        arguments: [:path_or_url, :stack_name],
+      },
     }
 
     class << self

--- a/lib/kumogata2/client.rb
+++ b/lib/kumogata2/client.rb
@@ -156,6 +156,13 @@ class Kumogata2::Client
     JSON.pretty_generate(summary).colorize_as(:json)
   end
 
+  def dump_template(path_or_url, stack_name)
+    stack_name = normalize_stack_name(stack_name)
+    validate_stack_name(stack_name)
+    template = open_template(path_or_url)
+    puts convert_output_value(template, false)
+  end
+
   private
 
   def get_client

--- a/lib/kumogata2/version.rb
+++ b/lib/kumogata2/version.rb
@@ -1,3 +1,3 @@
 module Kumogata2
-  VERSION = '0.1.17'
+  VERSION = '0.1.18'
 end


### PR DESCRIPTION
ただテンプレートを出力するだけのオプションを追加

* 既存機能はexportはリモートのテンプレートをfetchして出力
* dump_templateはローカルのテンプレートファイルから生成されたyamlを出力

kumogata2コマンドによるCLI経由でのstackの適用は 51200バイトの制限があるが、dump_templateを利用してテンプレートを取得し、S3経由でファイルをアップロードするとこれを回避できる